### PR TITLE
feat: Implement random operand generation for arithmetic quiz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,136 @@ version = 3
 [[package]]
 name = "arithmetic-operations-quiz"
 version = "0.1.0"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.161"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 name = "arithmetic-operations-quiz"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+rand = "0.8.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,44 @@
+use rand::Rng;
+
 fn main() {
-    println!("1 + 1 = ??");
+    let op1 = rand::thread_rng().gen_range(1..100);
+    let op2 = rand::thread_rng().gen_range(1..100);
+
+    println!("{} + {} = ??", op1, op2);
     println!("?? の値を入力してください:");
     let mut ans_input = String::new(); // ユーザーからの回答を保持する変数
                                        // 標準入力から1行取得して、ans_input に代入する
     std::io::stdin().read_line(&mut ans_input).unwrap();
 
-    // ans_inputからtrimで改行を取り除き、parseで整数(u32)に変換する
-    let ans_input = ans_input.trim().parse::<u32>().unwrap();
+    // ans_inputからtrimで改行を取り除き、parseで整数(i32)に変換する
+    let ans_input = ans_input.trim().parse::<i32>().unwrap();
 
-    dbg!(ans_input); // 実行後に入力された値を確認
+    dbg!(ans_input);
 
-    if ans_input == 1 + 1 {
+    if ans_input == op1 + op2 {
         println!("正解!");
     } else {
         println!("不正解!");
     }
 
-    println!("1 - 4 = ??");
+
+    let op1 = rand::thread_rng().gen_range(1..100);
+    let op2 = rand::thread_rng().gen_range(1..100);
+
+    println!("{} - {} = ??", op1, op2);
     println!("?? の値を入力してください:");
     let mut ans_input = String::new(); // ユーザーからの回答を保持する変数
                                        // 標準入力から1行取得して、ans_input に代入する
     std::io::stdin().read_line(&mut ans_input).unwrap();
 
-    let ans_input = ans_input.trim().parse::<isize>().unwrap();
+    // ans_inputからtrimで改行を取り除き、parseで整数(i32)に変換する
+    let ans_input = ans_input.trim().parse::<i32>().unwrap();
 
-    dbg!(ans_input); // 実行後に入力された値を確認
+    dbg!(ans_input);
 
-    if ans_input == 1 - 4 {
+    if ans_input == op1 - op2 {
         println!("正解!");
     } else {
         println!("不正解!");
     }
-
-    println!("i32 が扱えるデータ範囲: {} ~ {}", isize::MIN, isize::MAX);
-    println!("u32 が扱えるデータ範囲: {} ~ {}", usize::MIN, usize::MAX);
 }


### PR DESCRIPTION
- `rand` クレートを依存関係として追加し、ランダムなオペランドの生成を実装
- 加算と減算のクイズで、それぞれのオペレーションで異なるランダムな数値を使用
- ユーザー入力のパースタイプを `i32` に統一し、プログラムの一貫性を向上